### PR TITLE
UX Design Fixes Daniel

### DIFF
--- a/client/src/components/CreateAccount/CreateAccountForm.jsx
+++ b/client/src/components/CreateAccount/CreateAccountForm.jsx
@@ -134,12 +134,12 @@ function CreateAccountForm(props) {
 
         <div>
           <label className="image-label" for="imgURL">
-            IMAGE URL
+            IMAGE
           </label>
           <input
             className="account-input"
             name="imgURL"
-            placeholder="Image URL"
+            placeholder="Enter image URL"
             required
             value={user.imgURL}
             autoFocus

--- a/client/src/components/CreateAccount/CreateAccountForm.jsx
+++ b/client/src/components/CreateAccount/CreateAccountForm.jsx
@@ -14,15 +14,15 @@ function CreateAccountForm(props) {
   `;
 
   const P = styled.p`
-      width: 50%;
-      white-space: wrap;
-      margin: 0 auto;
+    width: 50%;
+    white-space: wrap;
+    margin: 0 auto;
 
-      @media screen  and (max-width: 500px){
-        width: 100%;
+    @media screen and (max-width: 500px) {
+      width: 100%;
       white-space: nowrap;
-      }
-  `
+    }
+  `;
 
   const [user, setUser] = useState({
     name: "",
@@ -49,7 +49,7 @@ function CreateAccountForm(props) {
   };
 
   if (isCreated) {
-    alert(`Welcome to ROOT, ${user.name}!`)
+    alert(`Welcome to ROOT, ${user.name}!`);
     return <Redirect to={"/"} />;
   }
 
@@ -57,17 +57,22 @@ function CreateAccountForm(props) {
     <>
       <div className="picture-container">
         {props.imagePreview === "" ? (
-          <div onClick={() => props.setImagePreview(user.imgURL)} className="user-picture"> </div>
+          <div
+            onClick={() => props.setImagePreview(user.imgURL)}
+            className="user-picture"
+          >
+            {" "}
+          </div>
         ) : (
-          <ImagePreview src={props.imagePreview} alt="Error: Invalid Image URL" />
+          <ImagePreview
+            src={props.imagePreview}
+            alt="Error: Invalid Image URL"
+          />
         )}
         <div className="add-image">
-        <P
-          onClick={() => props.setImagePreview(user.imgURL)}
-        >
-            Preview
-            image
-        </P>
+          <P onClick={() => props.setImagePreview(user.imgURL)}>
+            Preview image
+          </P>
         </div>
       </div>
       <Form onSubmit={handleSubmit}>
@@ -164,9 +169,15 @@ function CreateAccountForm(props) {
             </Link>
             <button className="create-button">Create Account</button>
           </div>
-            <div className="already">
-          <p>  Already have an account? <Link to="/login"><span>Log in</span> </Link></p>
-           </div>
+          <div className="already">
+            <p>
+              {" "}
+              Already have an account?{" "}
+              <Link to="/login">
+                <span>Log in</span>{" "}
+              </Link>
+            </p>
+          </div>
         </div>
       </Form>
     </>

--- a/client/src/components/CreateAccount/CreateAccountForm.jsx
+++ b/client/src/components/CreateAccount/CreateAccountForm.jsx
@@ -57,13 +57,12 @@ function CreateAccountForm(props) {
     <>
       <div className="picture-container">
         {props.imagePreview === "" ? (
-          <div className="user-picture"> </div>
+          <div onClick={() => props.setImagePreview(user.imgURL)} className="user-picture"> </div>
         ) : (
           <ImagePreview src={props.imagePreview} alt="Error: Invalid Image URL" />
         )}
         <div className="add-image">
         <P
-          className=""
           onClick={() => props.setImagePreview(user.imgURL)}
         >
             Preview

--- a/client/src/components/CreateAccount/CreateUserForm.js
+++ b/client/src/components/CreateAccount/CreateUserForm.js
@@ -177,12 +177,12 @@ const Form = styled.form`
   .create-button:hover {
     cursor: pointer;
     box-shadow: 2px 3px 4px 1px #999;
-    text-shadow: 2px 2px 5px rgb(54, 54, 54);
+    transform: scale(1.005)
   }
   .take-me-back:hover {
     box-shadow: 2px 3px 4px 1px #999;
-    text-shadow: 2px 2px 5px #999;
     cursor: pointer;
+    transform: scale(1.005)
   }
   .bottom-container {
     position: relative;

--- a/client/src/components/CreateAccount/CreateUserForm.js
+++ b/client/src/components/CreateAccount/CreateUserForm.js
@@ -130,11 +130,16 @@ const Form = styled.form`
     text-decoration-thickness: 0.099rem;
   }
   .checkbox {
-    width: 40px;
+    width: 33px;
     border-radius: 5px;
-    height: 36px;
+    height: 26px;
     margin-right: 14px;
     align-items: center;
+    -moz-appearance:none;
+-webkit-appearance:none;
+-o-appearance:none;
+border: 1px solid #000000;
+
   }
   .checkbox:hover {
     cursor: pointer;

--- a/client/src/components/CreateAccount/CreateUserForm.js
+++ b/client/src/components/CreateAccount/CreateUserForm.js
@@ -44,8 +44,11 @@ const Form = styled.form`
   }
 
   .image-label {
-    margin-right: -40px;
-    left: -70px;
+    /* margin-right: -40px;
+    left: -70px; */
+    margin-right: 20px;
+    left: -15px;
+}
   }
   .zipcode-label {
     margin-right: -20px;

--- a/client/src/components/CreateAccount/CreateUserForm.js
+++ b/client/src/components/CreateAccount/CreateUserForm.js
@@ -44,12 +44,10 @@ const Form = styled.form`
   }
 
   .image-label {
-    /* margin-right: -40px;
-    left: -70px; */
     margin-right: 20px;
     left: -15px;
-}
   }
+
   .zipcode-label {
     margin-right: -20px;
     left: -50px;
@@ -111,6 +109,7 @@ const Form = styled.form`
     text-align: center;
     margin-top: 81px;
   }
+
   .already {
     display: flex;
     flex-direction: row;
@@ -120,30 +119,34 @@ const Form = styled.form`
     font-weight: 500;
     text-align: center;
   }
+
   span {
     color: #82a1ab;
   }
+
   span:hover {
     cursor: pointer;
     text-decoration: underline;
     text-decoration-color: #82a1ab;
     text-decoration-thickness: 0.099rem;
   }
+
   .checkbox {
     width: 33px;
     border-radius: 5px;
     height: 26px;
     margin-right: 14px;
     align-items: center;
-    -moz-appearance:none;
--webkit-appearance:none;
--o-appearance:none;
-border: 1px solid #000000;
-
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    -o-appearance: none;
+    border: 1px solid #000000;
   }
+
   .checkbox:hover {
     cursor: pointer;
   }
+
   .create-button {
     font-family: "Montserrat", sans-serif;
     font-size: 24px;
@@ -185,12 +188,12 @@ border: 1px solid #000000;
   .create-button:hover {
     cursor: pointer;
     box-shadow: 2px 3px 4px 1px #999;
-    transform: scale(1.005)
+    transform: scale(1.005);
   }
   .take-me-back:hover {
     box-shadow: 2px 3px 4px 1px #999;
     cursor: pointer;
-    transform: scale(1.005)
+    transform: scale(1.005);
   }
   .bottom-container {
     position: relative;

--- a/client/src/components/PoliciesInitiatives/SanFranPolicy/SanFranPolicyStatic.jsx
+++ b/client/src/components/PoliciesInitiatives/SanFranPolicy/SanFranPolicyStatic.jsx
@@ -125,7 +125,7 @@ function SanFranPolicyStatic() {
                 </div>
               </div>
             <p className="get-involved">Get Involved</p>
-            <div className="content-container">
+            <div className="content-container-mobile">
             <img
                 className="content-image"
                 src="https://i.imgur.com/bgRDJbf.jpg"

--- a/client/src/components/PoliciesInitiatives/SanFranPolicy/StyledSanFran.js
+++ b/client/src/components/PoliciesInitiatives/SanFranPolicy/StyledSanFran.js
@@ -90,9 +90,10 @@ const StyledSanFran = styled.div`
   }
 
   .content-image {
-    width: 1204px;
+    width: 1202px;
     height: 319px;
     max-width: 83.5vw;
+    object-fit: fill;
   }
 
   .box-text-container {
@@ -141,6 +142,11 @@ const StyledSanFran = styled.div`
     margin: 16px 19px 16px 19px;
   }
 
+  .content-container-mobile {
+    display: none;
+    flex-flow: column nowrap;
+    margin: 16px 19px 16px 19px;
+  }
   .image-text {
     position: absolute;
     font-family: "Montserrat", sans-serif;
@@ -187,6 +193,8 @@ const StyledSanFran = styled.div`
       width: 400px;
     }
 
+
+
     .box-text-container {
       width: 70vw;
       max-height: 20vh;
@@ -215,6 +223,7 @@ const StyledSanFran = styled.div`
       font-size: 24px;
       margin: 0 auto;
     }
+
     .in-works {
       display: flex;
       font-family: Montserrat, sans-serif;
@@ -256,6 +265,7 @@ const StyledSanFran = styled.div`
       margin-top: 10px;
       white-space: nowrap;
     }
+
     span:hover {
       cursor: pointer;
       text-decoration: underline;
@@ -290,6 +300,11 @@ const StyledSanFran = styled.div`
       margin: 16px 19px 16px 19px;
     }
 
+    .content-container-mobile{
+      display: flex;
+      flex-flow: row nowrap;
+      margin: 16px 19px 16px 19px;
+    }
     .content-image {
       display: none;
     }

--- a/client/src/components/PoliciesInitiatives/SanFranPolicy/StyledSanFran.js
+++ b/client/src/components/PoliciesInitiatives/SanFranPolicy/StyledSanFran.js
@@ -193,8 +193,6 @@ const StyledSanFran = styled.div`
       width: 400px;
     }
 
-
-
     .box-text-container {
       width: 70vw;
       max-height: 20vh;
@@ -242,6 +240,7 @@ const StyledSanFran = styled.div`
       margin-right: auto;
       margin-left: 8px;
     }
+
     .mobile-image {
       display: flex;
       max-width: 4rem;
@@ -259,6 +258,7 @@ const StyledSanFran = styled.div`
       white-space: nowrap;
       margin: 5px auto;
     }
+
     span {
       display: flex;
       color: #3d3d3d;
@@ -272,10 +272,12 @@ const StyledSanFran = styled.div`
       text-decoration-color: #759f5c;
       text-decoration-thickness: 0.1rem;
     }
+
     .wrapper {
       display: flex;
       flex-direction: column-reverse;
     }
+
     .box-text-container {
       background: #fff;
       overflow-y: elipsis;
@@ -285,9 +287,11 @@ const StyledSanFran = styled.div`
       margin-bottom: 20px;
       margin-left: 20px;
     }
+
     .box-text {
       display: none;
     }
+
     .box-text-mobile {
       display: flex;
       color: #3d3d3d;
@@ -300,14 +304,16 @@ const StyledSanFran = styled.div`
       margin: 16px 19px 16px 19px;
     }
 
-    .content-container-mobile{
+    .content-container-mobile {
       display: flex;
       flex-flow: row nowrap;
       margin: 16px 19px 16px 19px;
     }
+
     .content-image {
       display: none;
     }
+
     .input-container {
       display: none;
     }

--- a/client/src/components/shared/Header/Burger.jsx
+++ b/client/src/components/shared/Header/Burger.jsx
@@ -13,7 +13,8 @@ const StyledBurger = styled.div`
   margin-left: 20px;
   
   &:hover {
-    cursor: pointer;
+    cursor: pointer;  
+    box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25);
   }
 
   @media (max-width: 500px) {
@@ -25,7 +26,7 @@ const StyledBurger = styled.div`
     width: 2.4rem;
     height: 0.2rem;
     background-color: #3d3d3d;
-    box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25);
+    /* box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25); */
   }
 `;
 

--- a/client/src/components/shared/Header/Header.css
+++ b/client/src/components/shared/Header/Header.css
@@ -32,7 +32,7 @@
 
 .dropdown-span:hover {
   cursor: pointer;
-  max-width: 80%;
+  max-width: 77.5%;
   padding-bottom: 5px;
   position: relative;
 }

--- a/client/src/components/shared/Header/Header.css
+++ b/client/src/components/shared/Header/Header.css
@@ -30,6 +30,44 @@
   border-width: 50%;
 }
 
+.dropdown-span:hover {
+  cursor: pointer;
+  max-width: 80%;
+  padding-bottom: 5px;
+  position: relative;
+}
+
+.dropdown-span:hover:after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #759f5c;
+  height: 3px;
+  border-radius: 10px;
+  border-width: 50%;
+}
+
+.dropdown-span2:hover {
+  cursor: pointer;
+  max-width: 81.2%;
+  padding-bottom: 5px;
+  position: relative;
+}
+
+.dropdown-span2:hover:after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #759f5c;
+  height: 3px;
+  border-radius: 10px;
+  border-width: 50%;
+}
+
 .menu {
   display: flex;
   align-content: center;
@@ -131,7 +169,9 @@
   position: fixed;
   margin-top: 55px;
   margin-left: -15px;
-  width: 100%;
+  /* width: 100%; */
+  
+  white-space: nowrap;
 }
 
 .dropdown-item {
@@ -169,6 +209,8 @@
     padding-bottom: 5px;
     position: relative;
   }
+
+  
   .header-image2 {
     display: none;
   }

--- a/client/src/components/shared/Header/Header.css
+++ b/client/src/components/shared/Header/Header.css
@@ -170,7 +170,7 @@
   margin-top: 55px;
   margin-left: -15px;
   /* width: 100%; */
-  
+
   white-space: nowrap;
 }
 
@@ -210,7 +210,6 @@
     position: relative;
   }
 
-  
   .header-image2 {
     display: none;
   }

--- a/client/src/components/shared/Header/Header.css
+++ b/client/src/components/shared/Header/Header.css
@@ -51,7 +51,7 @@
 
 .dropdown-span2:hover {
   cursor: pointer;
-  max-width: 84.3%;
+  max-width: 84.5%;
   padding-bottom: 5px;
   position: relative;
 }

--- a/client/src/components/shared/Header/Header.css
+++ b/client/src/components/shared/Header/Header.css
@@ -51,7 +51,7 @@
 
 .dropdown-span2:hover {
   cursor: pointer;
-  max-width: 81.2%;
+  max-width: 84.3%;
   padding-bottom: 5px;
   position: relative;
 }

--- a/client/src/components/shared/Header/Header.css
+++ b/client/src/components/shared/Header/Header.css
@@ -11,22 +11,22 @@
   min-width: 100%;
 }
 
-.header-span:hover{
+.header-span:hover {
   cursor: pointer;
   max-width: 100%;
   padding-bottom: 5px;
-  position:relative;
+  position: relative;
 }
 
-.header-span:hover:after{
-  content:'';
-  position:absolute;
-  bottom:0;
-  left:0;
-  right:0;
+.header-span:hover:after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
   background: #759f5c;
   height: 3px;
-  border-radius:10px;
+  border-radius: 10px;
   border-width: 50%;
 }
 
@@ -71,7 +71,6 @@
 .header-image {
   height: 100px;
   width: 100px;
-
 }
 
 .header-image2 {
@@ -82,7 +81,7 @@
   position: absolute;
 }
 
-.header-image-user{
+.header-image-user {
   border-radius: 50%;
   max-width: 70px;
   max-height: 70px;
@@ -94,13 +93,13 @@
   display: none;
 }
 
-.root-image{
+.root-image {
   display: none;
   max-height: 45px;
 }
 
-.root-image2{
-  display:none;
+.root-image2 {
+  display: none;
   max-height: 55px;
   max-width: 300px;
   margin-left: 250px;
@@ -108,17 +107,17 @@
   top: 10px;
 }
 
-.profile-pic{
+.profile-pic {
   display: none;
 }
 
-.userpic-container{
+.userpic-container {
   position: fixed;
   top: 17px;
   right: 5px;
 }
 
-.root-image-container{
+.root-image-container {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -146,41 +145,42 @@
   margin-bottom: 0px;
 }
 
-
 @media (max-width: 500px) {
-.header {
-  padding: initial;
-}
+  .header {
+    padding: initial;
+  }
 
   .header-image {
     display: none;
   }
-  
-  .header-image-user{
+
+  .header-image-user {
     display: none;
   }
 
-  .header-home{
+  .header-home {
     margin-top: -250px;
     margin-right: 90px;
   }
 
-  .header-span:active{
+  .header-span:active {
     cursor: pointer;
     max-width: 100%;
     padding-bottom: 5px;
-    position:relative;
+    position: relative;
   }
-
-  .header-span:active:after{
-    content:'';
-    position:absolute;
-    bottom:0;
-    left:0;
-    right:0;
+  .header-image2 {
+    display: none;
+  }
+  .header-span:active:after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
     background: #759f5c;
     height: 3px;
-    border-radius:10px;
+    border-radius: 10px;
   }
 
   .header-link:hover {
@@ -193,7 +193,7 @@
     padding: initial;
   }
 
-  .profile-pic{
+  .profile-pic {
     display: flex;
     max-width: 50px;
     background-color: #999;
@@ -204,12 +204,11 @@
     display: block;
     padding: 1px;
     margin-top: 10px;
-    
   }
-.header{
-  background-color: #f2f2f2;
-  height: 9vh;
-}
+  .header {
+    background-color: #f2f2f2;
+    height: 9vh;
+  }
   .burger-image {
     display: flex;
     max-width: 50px;
@@ -217,5 +216,4 @@
     left: 17%;
     margin-right: 15px;
   }
-
 }

--- a/client/src/components/shared/Header/Header.jsx
+++ b/client/src/components/shared/Header/Header.jsx
@@ -179,8 +179,8 @@ function Header({ open, setOpen }) {
                   <Link className="header-link header-span" id='header-account-link' onMouseOver={handleMouseOver}>Account</Link>
                   {openDropdown ?
                     <div className='dropdownmenu'>
-                    <Link className="dropdown-item header-span" to="login">LOGIN/ REGISTER</Link>
-                    <Link className="dropdown-item header-span" to="manage-your-account">MANAGE ACCOUNT</Link>
+                    <Link className="dropdown-item dropdown-span" to="login">LOGIN/ REGISTER</Link>
+                    <Link className="dropdown-item dropdown-span2" to="manage-your-account">MANAGE ACCOUNT</Link>
                   </div>
                   :
                   <></>

--- a/client/src/components/shared/Header/Ul.js
+++ b/client/src/components/shared/Header/Ul.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled from "styled-components";
 
 const Ul = styled.ul`
   list-style: none;
@@ -6,11 +6,11 @@ const Ul = styled.ul`
   align-items: space-evenly;
   justify-content: space-evenly;
   align-items: center;
-  
+
   li {
     text-transform: uppercase;
   }
-  
+
   @media (max-width: 500px) {
     flex-flow: column nowrap;
     background-color: #e8e4d9;

--- a/client/src/screens/CreateAccount/CreateAccount.jsx
+++ b/client/src/screens/CreateAccount/CreateAccount.jsx
@@ -21,7 +21,6 @@ function AddTransportationType() {
             imagePreview={imagePreview}
             setImagePreview={setImagePreview}
           />
-          
         </div>
       </StyledDiv>
     </Layout>

--- a/client/src/screens/CreateAccount/StyledCreateAccount.js
+++ b/client/src/screens/CreateAccount/StyledCreateAccount.js
@@ -45,6 +45,8 @@ a {
 
   .user-picture:hover{
     cursor: pointer;
+    box-shadow: 2px 2px 2px 2px #999;
+    transform: scale(1.000)
   }
 
 .add-image{
@@ -52,7 +54,6 @@ a {
 }
 .add-image:hover{
   cursor: pointer;
-  text-shadow: 1px 2px #999;
 }
 
 .middle-container {

--- a/client/src/screens/CreateAccount/StyledCreateAccount.js
+++ b/client/src/screens/CreateAccount/StyledCreateAccount.js
@@ -45,7 +45,8 @@ a {
 
   .user-picture:hover{
     cursor: pointer;
-    box-shadow: 2px 2px 2px 2px #999;
+    background: #999;
+    border: 2px solid #999;
     transform: scale(1.000)
   }
 

--- a/client/src/screens/CreateAccount/StyledCreateAccount.js
+++ b/client/src/screens/CreateAccount/StyledCreateAccount.js
@@ -1,148 +1,137 @@
-import styled from 'styled-components'
+import styled from "styled-components";
 
 let StyledDiv = styled.div`
-.top-container {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-a {
-  text-decoration: none;
-  color: #3d3d3d;
-}
-.top-left-container {
-  margin-left: -40px;
-  flex-direction: row;
-}
-
-.title{
-  white-space: nowrap;
-}
-
-
-.picture-container{
-  display: flex;
-  flex-direction: column;
-  text-align: center;
-  position: relative;
-  top: 38px;
-  left: 50px;
-  margin: 0 auto;
-  margin-bottom: auto;
-  padding-right: 10px;
-  margin-right: 20px;
-}
-
-  .user-picture {
-  background: #c4c4c4;
-  border: 2px solid #c4c4c4;
-  width: 120px;
-  height: 120px;
-  border-radius: 50%;
+  .top-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
   }
 
+  a {
+    text-decoration: none;
+    color: #3d3d3d;
+  }
+  .top-left-container {
+    margin-left: -40px;
+    flex-direction: row;
+  }
 
-  .user-picture:hover{
+  .title {
+    white-space: nowrap;
+  }
+
+  .picture-container {
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+    position: relative;
+    top: 38px;
+    left: 50px;
+    margin: 0 auto;
+    margin-bottom: auto;
+    padding-right: 10px;
+    margin-right: 20px;
+  }
+
+  .user-picture {
+    background: #c4c4c4;
+    border: 2px solid #c4c4c4;
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+  }
+
+  .user-picture:hover {
     cursor: pointer;
     background: #999;
     border: 2px solid #999;
-    transform: scale(1.000)
+    transform: scale(1);
   }
 
-.add-image{
-  margin-top: 10px
-}
-.add-image:hover{
-  cursor: pointer;
-}
+  .add-image {
+    margin-top: 10px;
+  }
+  .add-image:hover {
+    cursor: pointer;
+  }
 
-.middle-container {
-  display: flex;
-  align-items: flex-end;
-  margin-top: 106px;
-  margin-bottom: 150px;
-  justify-content: center;
-}
-
-.middle-right {
-  flex-flow: column;
-  align-items: flex-end;
-}
-
-.middle-left {
-  flex-direction: column;
-  align-items: flex-start;
-}
-
-
-
-@media screen and (max-width: 768px) {
-  .top-container {
+  .middle-container {
     display: flex;
-    flex-flow: column wrap;
+    align-items: flex-end;
+    margin-top: 106px;
+    margin-bottom: 150px;
     justify-content: center;
+  }
+
+  .middle-right {
+    flex-flow: column;
+    align-items: flex-end;
+  }
+
+  .middle-left {
+    flex-direction: column;
     align-items: flex-start;
-    margin: 0 auto;
   }
 
+  @media screen and (max-width: 768px) {
+    .top-container {
+      display: flex;
+      flex-flow: column wrap;
+      justify-content: center;
+      align-items: flex-start;
+      margin: 0 auto;
+    }
 
-  .top-left-container {
-    margin: 0 auto;
+    .top-left-container {
+      margin: 0 auto;
+    }
+
+    .top-right-container {
+      margin: 0 auto;
+      margin-top: -10px;
+    }
+
+    .middle-container {
+      display: flex;
+      flex-flow: column nowrap;
+      margin: 20px;
+      margin-bottom: 150px;
+    }
+
+    .root-logo {
+      width: 400px;
+    }
+    .title {
+      width: 400px;
+      white-space: pre-wrap;
+    }
   }
 
- 
-  .top-right-container {
-    margin: 0 auto;
-    margin-top: -10px;
+  @media screen and (max-width: 500px) {
+    .title {
+      width: 100vw;
+    }
   }
 
-  .middle-container {
-    display: flex;  
-    flex-flow: column nowrap;
-    margin: 20px;
-    margin-bottom: 150px;
-  }
+  @media screen and (max-width: 1000px) {
+    .top-container {
+      display: flex;
+      flex-flow: column wrap;
+      left: 0;
+    }
 
-  .root-logo{
-    width: 400px;
-  }
-  .title{
-    width:400px;
-    white-space: pre-wrap;
-  }
-}
+    .picture-container {
+      margin: 0 auto;
+      margin-bottom: 50px;
+      left: 0%;
+    }
 
-@media screen and (max-width: 500px) {
-  .title{
-    width: 100vw;
+    .middle-container {
+      display: flex;
+      flex-flow: column nowrap;
+      margin: 20px;
+      margin-bottom: 150px;
+    }
   }
-}
-@media screen and (max-width: 1000px) {
-  .top-container {
-    display: flex;
-    flex-flow: column wrap;
-    left: 0; 
-  }
-
-  .logo-title-container{
-  }
-.picture-container{
-margin:0 auto;
-margin-bottom: 50px;
-left: 0%;
-}
-
-  .middle-container {
-    display: flex;  
-    flex-flow: column nowrap;
-    margin: 20px;
-    margin-bottom: 150px;
-
-  }
-
-  
-  
-}
-`
-export default StyledDiv
+`;
+export default StyledDiv;

--- a/client/src/screens/CreateAccount/StyledCreateAccount.js
+++ b/client/src/screens/CreateAccount/StyledCreateAccount.js
@@ -26,7 +26,7 @@ a {
   flex-direction: column;
   text-align: center;
   position: relative;
-  top: 40px;
+  top: 38px;
   left: 50px;
   margin: 0 auto;
   margin-bottom: auto;
@@ -47,7 +47,9 @@ a {
     cursor: pointer;
   }
 
-
+.add-image{
+  margin-top: 10px
+}
 .add-image:hover{
   cursor: pointer;
   text-shadow: 1px 2px #999;

--- a/client/src/screens/Error/styledError.js
+++ b/client/src/screens/Error/styledError.js
@@ -1,42 +1,42 @@
 import styled from "styled-components";
 
 const StyledError = styled.div`
-display: flex;
-flex-direction: column;
-font-family: 'Montserrat', sans serif;
-color: #3d3d3d;
-font-size: 24px;
-font-weight: bold;
-text-align: center;
-text-transform: uppercase;
-margin-bottom: 100px;
+  display: flex;
+  flex-direction: column;
+  font-family: "Montserrat", sans serif;
+  color: #3d3d3d;
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+  text-transform: uppercase;
+  margin-bottom: 100px;
 
-a {
-  text-decoration: none;
-  color: #749f5c;
-  font-size: 36px;
-  font-weight: normal;
-  font-family: 'Montserrat', sans serif;
-}
+  a {
+    text-decoration: none;
+    color: #749f5c;
+    font-size: 36px;
+    font-weight: normal;
+    font-family: "Montserrat", sans serif;
+  }
 
-h1:hover{
-  cursor: default;
-}
+  h1:hover {
+    cursor: default;
+  }
 
-p {
-  color: #000000;
-  margin-bottom: 20px;  
-}
+  p {
+    color: #000000;
+    margin-bottom: 20px;
+  }
 
-a:hover{
-  text-shadow: 1px 1px #999;
-}
+  a:hover {
+    text-shadow: 1px 1px #999;
+  }
 
-img {
-  width: 360px;
-  margin: 0 auto;
-  padding: 50px;
-}
-`
+  img {
+    width: 360px;
+    margin: 0 auto;
+    padding: 50px;
+  }
+`;
 
 export default StyledError;


### PR DESCRIPTION
as the UX Design team requested:

fixes in `CreateAccount.jsx/CreateAccountForm.jsx`:

- Grey circle now has a hover state
- "preview image" now has a margin between itself and image/grey circle
- placeholder font-color fixed and is now a light grey.
- label for Image url now says "Image" instead of "Image URL" and placeholder says "Enter Image URL"
- got rid of text-shadow hover state for "preview image"
- gave checkbox the proper styling

fixes in `SanFranPolicy.jsx`:
- images in sanfran policy were a bit wider than the text container, fixed.
- Divestment from Petroleum no longer appears on desktop and is now exclusive to mobile media query

fixes in 'header.css/header.jsx':
- dropdown menu for login and account underline length fixed